### PR TITLE
Bugfix for buttons in start menu and level completed menu

### DIFF
--- a/scripts/level_completed.gd
+++ b/scripts/level_completed.gd
@@ -6,8 +6,14 @@ signal next_level()
 @onready var retry_button: Button = %RetryButton
 @onready var next_level_button: Button = %NextLevelButton
 
+func optionSelected() -> void:
+	retry_button.disabled = true
+	next_level_button.disabled = true
+
 func _on_retry_button_pressed() -> void:
+	optionSelected()
 	retry.emit()
 
 func _on_next_level_button_pressed() -> void:
+	optionSelected()
 	next_level.emit()

--- a/scripts/start_menu.gd
+++ b/scripts/start_menu.gd
@@ -7,6 +7,7 @@ func _ready():
 	start_game_button.grab_focus()
 	
 func _on_start_game_button_pressed() -> void:
+	start_game_button.disabled = true
 	await LevelTransition.fade_to_black()
 	get_tree().change_scene_to_file("res://scenes/level_one.tscn")
 	LevelTransition.fade_from_black()


### PR DESCRIPTION
## Description
Selecting buttons in menus such as "Start Game" or "Retry" too fast crashes the game. This appears to be from the connected functions emitting 2 signals at the same time. This causes the `get_tree()` function to fail on the second call.

## Reproduce
Start the game while rapidly tapping the select/jump key.

## Fix
Disable buttons on selection.